### PR TITLE
Fixed bug when location int parsing fails

### DIFF
--- a/lib/src/entities/location.dart
+++ b/lib/src/entities/location.dart
@@ -3,11 +3,14 @@ class GoogleGeocodingLocation {
   const GoogleGeocodingLocation({required this.lat, required this.lng});
 
   /// [GoogleGeocodingLocation] From Json factory
-  factory GoogleGeocodingLocation.fromJson(Map<String, dynamic> json) =>
-      GoogleGeocodingLocation(
-        lat: json['lat'] as double,
-        lng: json['lng'] as double,
-      );
+  factory GoogleGeocodingLocation.fromJson(Map<String, dynamic> json) {
+    final lat = json['lat'];
+    final lng = json['lng'];
+    return GoogleGeocodingLocation(
+      lat: lat is int ? lat.toDouble() : lat as double,
+      lng: lng is int ? lng.toDouble() : lng as double,
+    );
+  }
 
   /// Latitude
   final double lat;


### PR DESCRIPTION
If you try to check locations by int coordinates - decoding from json will fail. This PR fixes the issue.